### PR TITLE
Resolves #11

### DIFF
--- a/expr/02_surge2steady/sifs/pseudo_surge.sif
+++ b/expr/02_surge2steady/sifs/pseudo_surge.sif
@@ -130,7 +130,7 @@ Initial Condition 1
   Enthalpy_h       = Equals "Enthalpy_h"    ! [J kg-1]
   Temperature      = Equals "Temperature"   ! [C]
   Water Content    = Equals "Water Content" ! [-]
-  Surface Enthalpy = Equals "Surface Enthalpy"
+  Surface Enthalpy = Equals "Surface_Enthalpy"
   
 End
 

--- a/expr/03_PeriodicSurge/sifs/periodic_surge.sif
+++ b/expr/03_PeriodicSurge/sifs/periodic_surge.sif
@@ -139,7 +139,7 @@ Initial Condition 1
   Enthalpy_h       = Equals "Enthalpy_h"    ! [J kg-1]
   Temperature      = Equals "Temperature"   ! [C]
   Water Content    = Equals "Water Content" ! [-]
-  Surface Enthalpy = Equals "Surface Enthalpy"
+  Surface Enthalpy = Equals "Surface_Enthalpy"
   
 End
 


### PR DESCRIPTION
Fixed variable name spelling. Time dependent air temperatures now work in prognostic simulations with a restart. 