### PR TITLE
Dask debug

### DIFF
--- a/expr/00_CoupledInit/run/crmpt12/postprocess.sh
+++ b/expr/00_CoupledInit/run/crmpt12/postprocess.sh
@@ -12,10 +12,8 @@
 
 # how many files to itterate over in a the for loop  
 CHUNK_SIZE=48
-# numbers of cores each job in the array will have
-export NUM_WORKERS=16
 # use a single thread per cpu core
-export THREADS_PER_WORKER=1
+export THREADS_PER_WORKER=8
 
 source ../../config/modulefile.cc.cedar
 

--- a/expr/01_UQ/run/crmpt12/postprocess.sh
+++ b/expr/01_UQ/run/crmpt12/postprocess.sh
@@ -9,10 +9,8 @@
 #SBATCH --output=dask_%A_%a.out              # standard output
 #SBATCH --error=dask_%A_%a.err               # standard error
 
-# numbers of cores each job in the array will have
-export NUM_WORKERS=16
 # use a single thread per cpu core
-export THREADS_PER_WORKER=1
+export THREADS_PER_WORKER=8
 
 source ../../config/modulefile.cc.cedar
 

--- a/expr/02_surge2steady/run/crmpt12/postprocess.sh
+++ b/expr/02_surge2steady/run/crmpt12/postprocess.sh
@@ -9,10 +9,8 @@
 #SBATCH --output=dask_%A_%a.out              # standard output
 #SBATCH --error=dask_%A_%a.err               # standard error
 
-# numbers of cores each job in the array will have
-export NUM_WORKERS=16
 # use a single thread per cpu core
-export THREADS_PER_WORKER=1
+export THREADS_PER_WORKER=8
 
 source ../../config/modulefile.cc.cedar
 
@@ -28,9 +26,6 @@ mkdir "${SLURM_TMPDIR}/thinned"
 if [ ! -d "result/${KEY}/thinned/" ]; then
   mkdir  "result/${KEY}/thinned/"
 fi
-
-# set up the dask cluter for the instance of the job array
-create_dask_cluster
 
 # post process the surge files
 for file in $(find ./result/${KEY}/nc/ -name "*.nc" -ctime -1); do 

--- a/expr/02_surge2steady/surge2steady.sh
+++ b/expr/02_surge2steady/surge2steady.sh
@@ -6,23 +6,6 @@ evenly_divisible()
   echo $(awk -v a=$1 -v b=$2 'BEGIN{print((a / b % 1) == 0)}')
 }
 
-create_dask_cluster()
-{
-  export SCHEDULER_FILE="${SLURM_JOB_ID}-scheduler.json"
-  dask scheduler --host 127.0.0.1 --no-dashboard --scheduler-file $SCHEDULER_FILE &
-  sleep 15
-
-  for worker in $(seq $NUM_WORKERS); do
-  dask worker --scheduler-file $SCHEDULER_FILE \
-              --no-dashboard \
-              --no-nanny \
-              --nworkers 1 \
-              --nthreads 1 &
-  done
-  sleep 15
-
-}
-
 post_proccess()
 {
   # copy the source file from scratch to local (compute node's) SSD

--- a/expr/03_PeriodicSurge/periodic_surge.sh
+++ b/expr/03_PeriodicSurge/periodic_surge.sh
@@ -345,39 +345,3 @@ periodic_simulation()
   # record the runtimes for future reference
   log_runtime $KEY $dx $T_ma $offset $ST_dt $SD_dt $QT_dt $QD_dt $SP $QP $TT $beta $runtime
 }
-
-create_dask_cluster()
-{
-  export SCHEDULER_FILE="${SLURM_JOB_ID}-scheduler.json"
-  dask scheduler --host 127.0.0.1 --no-dashboard --scheduler-file $SCHEDULER_FILE &
-  sleep 15
-
-  for worker in $(seq $NUM_WORKERS); do
-  dask worker --scheduler-file $SCHEDULER_FILE \
-              --no-dashboard \
-              --no-nanny \
-              --nworkers 1 \
-              --nthreads 1 &
-  done
-  sleep 15
-
-}
-
-post_proccess()
-{
-  # copy the source file from scratch to local (compute node's) SSD
-  time rsync -ah "result/${KEY}/nc/${run_name}.nc" "${SLURM_TMPDIR}"
-
-  # grid the NetCDF file written by the NetcdfUGRIDOutputSolver, 
-  # convert from NetCDF to Zarr file format
-  time grid_data.py -i "${SLURM_TMPDIR}/${run_name}.nc" \
-                    -o "${SLURM_TMPDIR}/${run_name}.zarr"  #\
-                    # -p "${param_dict}"
-
-  # tar the full zarr file, and write the tar to scratch
-  time tar -cf "result/${KEY}/gridded/${run_name}.zarr.tar" -C "${SLURM_TMPDIR}" "${run_name}.zarr"
-
-  # delete files from SSD to make room for next files
-  rm "${SLURM_TMPDIR}/${run_name}.nc"
-  rm -r "${SLURM_TMPDIR}/${run_name}.zarr"
-}

--- a/expr/03_PeriodicSurge/run/crmpt12/postprocess.sh
+++ b/expr/03_PeriodicSurge/run/crmpt12/postprocess.sh
@@ -1,76 +1,88 @@
 #!/bin/bash
+#SBATCH --array=0-9
 #SBATCH --job-name=dask_gridding
-#SBATCH --time=06:00:00           
+#SBATCH --time=01:30:00 
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=32
-#SBATCH --mem-per-cpu=8000M
-#SBATCH --mail-type=END                      # send all mail (way to much)
-#SBATCH --mail-user=andrew.d.nolan@maine.edu # email to spend updates too
-#SBATCH --output=dask_%A_%a.out              # standard output
-#SBATCH --error=dask_%A_%a.err               # standard error
+#SBATCH --mem-per-cpu=4096M
+#SBATCH --output=dask_%A.out
+#SBATCH --error=dask_%A.err
 
-# numbers of cores each job in the array will have
-export NUM_WORKERS=32
-# use a single thread per cpu core
-export THREADS_PER_WORKER=1
+export KEY='crmpt12'
+
+# number of files each member of the job array will process
+CHUNK_SIZE=11
+
+# because mostly numeric dominated (e.g. numpy) use a large number of threads
+export THREADS_PER_WORKER=16
 
 source ../../config/modulefile.cc.cedar
 
-# load the source functions
-source ./periodic_surge.sh
-
 parse_params()
 {   
-  IFS=" " read -r QP beta NT T_0<<< $(echo $line | cut -d " " -f 7,9,11,13)
+  IFS=" " read -r QP beta NT T_0<<< $(sed -n "${1}p" "run/${KEY}/${KEY}.commands" | cut -d " " -f 7,9,11,13)
 }
 
-KEY='crmpt12'
+post_proccess()
+{
+  parse_params $1
 
-# set up the dask cluter for the instance of the job array
-create_dask_cluster
+  # get the run name based on parsed parameters for the i-th run
+  # NOTE: default value which aren't varied are hard coded
+  run_name="${KEY}_dx_50_TT_${NT}.0_MB_-0.36_OFF_Tma_-8.5_B_${beta}_SP_2_QP_${QP}"
 
-# # post process the surge files
-# for file in $(find ./result/${KEY}/nc/ -name "${KEY}_dx_50_TT_3000.0*B_*.nc"); do 
-#     # get the base filename ,with no path info 
-#     fn="${file##*/}"
-#     # strip the file extension, to get the runname 
-#     run_name="${fn%%.nc}"
-#     # run the post processing commands
-#     post_proccess
-# done 
+  # based on the start time (T_0) and time intergration length (NT)
+  # caluculate the final time in kiloyears
+  T_f=$(awk -v T_0=$T_0 -v NT=$NT 'BEGIN {print (T_0 + NT)/1e3}')
+  # convert the start time from years to kiloyears
+  T_0=$(awk -v T_0=$T_0 'BEGIN {print T_0/1e3}')
 
+  # rename the file based on the restart point and integration length
+  new_name="${KEY}_dx_50_TT_${T_0}--${T_f}ka_MB_-0.36_OFF_Tma_-8.5_B_${beta}_SP_2_QP_${QP}"
 
-while IFS="" read -r line || [ -n "$line" ]; do
-    # only parse the parameters that actually vary 
-    parse_params $line
-    # get the run name based on parsed parameters for the i-th run
-    # NOTE: default value which aren't varied are hard coded
-    run_name="${KEY}_dx_50_TT_${NT}.0_MB_-0.36_OFF_Tma_-8.5_B_${beta}_SP_2_QP_${QP}"
+  # rename restart files
+  mv "result/${KEY}/mesh_dx50/${run_name}.result"\
+     "result/${KEY}/mesh_dx50/${new_name}.result"
 
-    # based on the start time (T_0) and time intergration length (NT)
-    # caluculate the final time in kiloyears
-    T_f=$(awk -v T_0=$T_0 -v NT=$NT 'BEGIN {print (T_0 + NT)/1e3}')
-    # convert the start time from years to kiloyears
-    T_0=$(awk -v T_0=$T_0 'BEGIN {print T_0/1e3}')
+  # rename the "raw" netcdf files
+  mv "result/${KEY}/nc/${run_name}.nc"\
+     "result/${KEY}/nc/${new_name}.nc"
 
-    # rename the file based on the restart point and integration length
-    new_name="${KEY}_dx_50_TT_${T_0}--${T_f}ka_MB_-0.36_OFF_Tma_-8.5_B_${beta}_SP_2_QP_${QP}"
+  # overwrite the runname with the updated name,
+  # we postprocess after renaming so the files packed into the zarr archieves have 
+  # the correct filenames when unpacked
+  run_name="${new_name}"
 
-    # rename restart files
-    mv "result/${KEY}/mesh_dx50/${run_name}.result"\
-       "result/${KEY}/mesh_dx50/${new_name}.result"
+  # copy the source file from scratch to local (compute node's) SSD
+  time rsync -ah "result/${KEY}/nc/${run_name}.nc" "${SLURM_TMPDIR}"
 
-    # rename the "raw" netcdf files
-    mv "result/${KEY}/nc/${run_name}.nc"\
-       "result/${KEY}/nc/${new_name}.nc"
+  # grid the NetCDF file written by the NetcdfUGRIDOutputSolver, 
+  # convert from NetCDF to Zarr file format
+  time grid_data.py -i "${SLURM_TMPDIR}/${run_name}.nc" \
+                    -o "${SLURM_TMPDIR}/${run_name}.zarr"  #\
+                    # -p "${param_dict}"
 
-    # overwrite the runname with the updated name,
-    # we postprocess after renaming so the files packed into the zarr archieves have 
-    # the correct filenames when unpacked
-    run_name="${new_name}"
+  # tar the full zarr file, and write the tar to scratch
+  time tar -cf "result/${KEY}/gridded/${run_name}.zarr.tar" -C "${SLURM_TMPDIR}" "${run_name}.zarr"
 
+  # delete files from SSD to make room for next files
+  rm "${SLURM_TMPDIR}/${run_name}.nc"
+  rm -r "${SLURM_TMPDIR}/${run_name}.zarr"
+
+}
+
+# get the number of simulations to process
+N=$(wc -l < "run/${KEY}/${KEY}.commands")
+
+# loop of the corresponding input files
+start=$((SLURM_ARRAY_TASK_ID * CHUNK_SIZE))
+stop=$((start + CHUNK_SIZE))
+for j in $(seq $start $stop); do 
+  # add one to j since sed is indexed at 1
+  j=$((j + 1))
+  # only ran 286 runs, so make sure we don't go over 
+  if [[ $j -le $N ]]; then 
     # run the post processing commands
-    post_proccess
-
-
-done <run/${KEY}/${KEY}.commands
+    post_proccess $j
+  fi
+done

--- a/src/thermal/thermal/open.py
+++ b/src/thermal/thermal/open.py
@@ -3,12 +3,6 @@ import xarray as xr
 from glob import glob
 from .derived_fields import calc_percent_temperate, calc_volume, calc_magnitude
 
-
-"""
-# open multiple zarr
-    https://discourse.pangeo.io/t/how-to-read-multiple-zarr-archives-at-once-from-s3/2564
-"""
-
 # dictionary of 1D variables and vertical index they are define along
 vars_1D = { "mass balance" : -1,
             "surface_enthalpy" : -1, 
@@ -28,26 +22,6 @@ rename_dict = {'velocity 1'   : 'vel_x',
                'stress 3'     : 'S_yy',
                'stress 4'     : 'S_xz',
                'enthalpy heat diffusivity' : 'kappa_cold'}
-
-def __quads_to_tris(quads):
-    """converts quad elements into tri elements
-    from: https://stackoverflow.com/a/59971611/10221482
-    """
-
-    tris = [[None for j in range(3)] for i in range(2*len(quads))]
-    for i in range(len(quads)):
-        j = 2*i
-        n0 = quads[i][0]
-        n1 = quads[i][1]
-        n2 = quads[i][2]
-        n3 = quads[i][3]
-        tris[j][0] = n0
-        tris[j][1] = n1
-        tris[j][2] = n2
-        tris[j + 1][0] = n2
-        tris[j + 1][1] = n3
-        tris[j + 1][2] = n0
-    return tris
 
 def __preprocess_UGRID(ds, out_fn=None):
     """Reshape the NetCDF from Elmer onto a structured grid.


### PR DESCRIPTION
Changes after extensive debugging of dask unmanaged memory warnings while post processing periodic surge results. 

All experiment have been switched to using multi-threading, since all computation are numeric (i.e. `numpy`, etc) dominated and having less workers will me less duplicated data, which will hopefully help with unmanaged memory. 

Switch to a `dask.distributed.LocalCluster` within the python script from the previous command line based cluster/worker initialization. The dask worker memory configuration options are crucial for getting post processing to run without failing. While those settings don't really seem to help diminish the amount of umanaged memory, they do allow the jobs to complete which is most important right now. 